### PR TITLE
Add deployment configuration for Primodium contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean:indexer": "pnpm clean-local-docker-indexer",
     "deploy:caldera": "pnpm --filter 'contracts' deploy:caldera",
     "deploy:caldera-sepolia": "pnpm --filter 'contracts' deploy:caldera-sepolia",
+    "deploy:happychain-sepolia": "pnpm --filter 'contracts' deploy:happychain-sepolia",
     "deploy:local": "pnpm --filter 'contracts' deploy:local",
     "deploy:redstone-holesky": "pnpm --filter 'contracts' deploy:redstone-holesky",
     "dev": "run-pty % pnpm --filter 'client' run dev % pnpm dev:core % pnpm dev:node % pnpm deploy:local % pnpm dev:indexer",

--- a/packages/contracts/.env.example
+++ b/packages/contracts/.env.example
@@ -1,0 +1,1 @@
+PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # anvil key 1

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -34,3 +34,7 @@ chain_id = 17001
 [profile.base-sepolia]
 eth_rpc_url = "https://sepolia.base.org"
 chain_id = 84532
+
+[profile.happychain-sepolia]
+eth_rpc_url = "https://rpc.testnet.happy.tech/http"
+chain_id = 216

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -19,6 +19,7 @@
     "deploy:base-sepolia": "pnpm mud deploy --profile=base-sepolia",
     "deploy:caldera": "pnpm mud deploy --profile=caldera",
     "deploy:caldera-sepolia": "pnpm mud deploy --profile=caldera-sepolia",
+    "deploy:happychain-sepolia": "pnpm mud deploy --profile=happychain-sepolia",
     "deploy:local": "pnpm mud deploy --skipBuild",
     "deploy:redstone-holesky": "pnpm mud deploy --profile=redstone-holesky",
     "dev": "pnpm mud dev-contracts",

--- a/packages/contracts/worlds.json
+++ b/packages/contracts/worlds.json
@@ -1,10 +1,14 @@
 {
+  "216": {
+    "address": "0x8a6012e36795ef498bb3e9ad20afd89f68db9d00",
+    "blockNumber": 939734
+  },
   "10017": {
     "address": "0xcdde8dc29bcb7a7b30e22318746dfd81f0510b43",
     "blockNumber": 8283703
   },
   "31337": {
-    "address": "0xd7117ee1d4563a596d3d06e68ef8e12d8fb83ccd"
+    "address": "0xc7f3101fdd9f5a1392c33bd43a3e633078c45865"
   },
   "84532": {
     "address": "0x6eda5e0ce08c96cee26b4ff16462bef938789495",


### PR DESCRIPTION
### TL;DR

Added support for deploying to HappyChain Sepolia testnet.

### What changed?

- Added a new deployment profile for HappyChain Sepolia in `foundry.toml` with RPC URL and chain ID 216
- Added new deployment scripts in package.json files for HappyChain Sepolia
- Added HappyChain Sepolia deployment address to worlds.json
- Updated local deployment address in worlds.json

### How to test?

Run the following command to deploy to HappyChain Sepolia:
```
pnpm deploy:happychain-sepolia
```