### PR TITLE
add deployed indexer url

### DIFF
--- a/packages/core/src/network/config/chainConfigs.ts
+++ b/packages/core/src/network/config/chainConfigs.ts
@@ -75,7 +75,7 @@ const baseSepolia: ChainConfig = {
 
 export const happyChainSepolia: ChainConfig = {
   ...happyChainDef,
-  indexerUrl: "http://148.113.212.211:3001", // ## [happyTODO :: deploy indexer and then add the URL here] ##
+  indexerUrl: "http://148.113.212.211:3001",
 };
 
 export type ChainConfig = MUDChain & { indexerUrl?: string };

--- a/packages/core/src/network/config/chainConfigs.ts
+++ b/packages/core/src/network/config/chainConfigs.ts
@@ -75,7 +75,7 @@ const baseSepolia: ChainConfig = {
 
 export const happyChainSepolia: ChainConfig = {
   ...happyChainDef,
-  indexerUrl: "http://148.113.212.211:3001",
+  indexerUrl: "https://primodium-indexer.happy.tech/",
 };
 
 export type ChainConfig = MUDChain & { indexerUrl?: string };

--- a/packages/core/src/network/config/chainConfigs.ts
+++ b/packages/core/src/network/config/chainConfigs.ts
@@ -75,7 +75,7 @@ const baseSepolia: ChainConfig = {
 
 export const happyChainSepolia: ChainConfig = {
   ...happyChainDef,
-  indexerUrl: "http://localhost:3001", // ## [happyTODO :: deploy indexer and then add the URL here] ##
+  indexerUrl: "http://148.113.212.211:3001", // ## [happyTODO :: deploy indexer and then add the URL here] ##
 };
 
 export type ChainConfig = MUDChain & { indexerUrl?: string };


### PR DESCRIPTION
### TL;DR

Updated the indexer URL for happyChainSepolia from localhost to a specific IP address.

### What changed?

Changed the `indexerUrl` for `happyChainSepolia` from `"http://localhost:3001"` to `"http://148.113.212.211:3001"`.

### How to test?
run `build:client-core` in the root folder, the client should then use the new indexer URL when it loads the happychain chainConfig from this file,`setupRecs` in `createNetwork` should ingest the same and then calls made to the indexer can be confirmed via the network tab on game load 

![Screenshot 2025-04-15 at 1.26.00 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/04qKkliMuuwaKjPzfrYQ/2667e760-73e4-44f0-b4de-795585cb4558.png)

 

