### PR TITLE
integrate happy session keys

### DIFF
--- a/packages/client/src/systems/setupSessionAccount.ts
+++ b/packages/client/src/systems/setupSessionAccount.ts
@@ -27,6 +27,7 @@ export const setupSessionAccount = async (core: Core, account: AccountClient) =>
     return true;
   }
 
+  // this is fully for mud's delegate system - we may need none of this for happy session keys
   const potentialAuthorizeds = query({ with: [tables.UserDelegationControl] }).reduce((prev, entity) => {
     const key = decodeEntity(tables.UserDelegationControl.metadata.abiKeySchema, entity) as {
       delegator: Address;

--- a/packages/client/src/util/localStorage.ts
+++ b/packages/client/src/util/localStorage.ts
@@ -1,4 +1,4 @@
-import { Hex } from "viem";
+import { Address, Hex } from "viem";
 
 import { STORAGE_PREFIX } from "@primodiumxyz/core";
 
@@ -35,3 +35,10 @@ export function getPrivateKey(publicKey: Hex): Hex | undefined {
   if (!entry) return;
   return entry as Hex;
 }
+
+// [HAPPY_PRIM] storage helpers for session keys
+export const HAPPY_STORAGE_PREFIX = "[HAPPY_PRIM] sessionKeyRegistered:";
+
+export const isHappySessionKeyRegistered = (address: Address): boolean => {
+  return localStorage.getItem(HAPPY_STORAGE_PREFIX + address) === "true";
+};


### PR DESCRIPTION
### TL;DR

Replaced MUD's session account system with Happy Wallet's session key implementation for a more streamlined user experience.

### What changed?

- Integrated `@happy.tech/core` library to handle session key management
- Replaced the custom private key generation and storage with Happy Wallet's `requestSessionKey` function
- Updated the UI to reflect the new session key approach with simplified messaging
- Added new localStorage helpers to track Happy session key registration status
- Removed complex private key management code and simplified the authorization flow
- Updated tooltips and UI text to reference Happy Wallet integration